### PR TITLE
Checkout page bug: The items were not displying in checkouproduct page.

### DIFF
--- a/src/Checkout.js
+++ b/src/Checkout.js
@@ -13,7 +13,7 @@ function Checkout() {
                 <div>
                     <h2 className="checkout__title">Your Shopping Basket</h2>
                     {/* All the basket items will go here */}
-                    {basket.map(item => {
+                    {basket.map(item => (
                         <CheckoutProduct
                             id={item.id}
                             title={item.title}
@@ -21,7 +21,7 @@ function Checkout() {
                             price={item.price}
                             rating={item.rating}
                         />
-                    })}
+                    ))}
                 </div>
             </div>
             <div className="checkout__right">


### PR DESCRIPTION
This bug was due to the wrong syntax used in the codebase. The code
should contain the circular bracket instead of curely brackets.

Fixes #3.